### PR TITLE
Remove period to fix link when clicked

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -95,7 +95,7 @@ export class MerossCloudPlatform implements DynamicPlatformPlugin {
           default:
             this.log.info(
               `A Meross Device has been discovered with Device Type: ${deviceDef.deviceType}, which is currently not supported.`,
-              'Enable Device Discovery on Plugin Settings, Then Submit Meross Cloud Info Here: https://git.io/JLD51.',
+              'Enable Device Discovery on Plugin Settings, Then Submit Meross Cloud Info Here: https://git.io/JLD51',
               //'Submit Feature Requests Here: https://git.io/JLD5y,',
             );
         }


### PR DESCRIPTION
From the logging output in `homebridge-config-ui-x` when you click the link to report device implementation needs the link will break due to the trailing period.